### PR TITLE
[Unimplemented call & Empty call] Fix Empty pojo scenario

### DIFF
--- a/vertx-grpc-protoc-plugin/src/main/java/com/lwlee2608/vertx/grpc/plugin/context/MessageContext.java
+++ b/vertx-grpc-protoc-plugin/src/main/java/com/lwlee2608/vertx/grpc/plugin/context/MessageContext.java
@@ -1,5 +1,7 @@
 package com.lwlee2608.vertx.grpc.plugin.context;
 
+import com.google.common.base.Strings;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +12,7 @@ public class MessageContext {
     public String packageName;
     public String protoPackage;
     public String name;
+    public String outerClass;
     public final List<FieldContext> fields = new ArrayList<>();
     public final Set<String> imports = new HashSet<>();
 
@@ -18,6 +21,10 @@ public class MessageContext {
     }
 
     public String protoFullName() {
-        return protoPackage + "." + className;
+        if (!Strings.isNullOrEmpty(outerClass) && className.equals("Empty")) {
+            return protoPackage + "." + outerClass + "." + className;
+        } else {
+            return protoPackage + "." + className;
+        }
     }
 }

--- a/vertx-grpc-test-rx2/src/test/java/com/lwlee2608/vertx/grpc/plugin/GoogleTest.java
+++ b/vertx-grpc-test-rx2/src/test/java/com/lwlee2608/vertx/grpc/plugin/GoogleTest.java
@@ -2,6 +2,7 @@ package com.lwlee2608.vertx.grpc.plugin;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos;
+import com.google.protobuf.pojo.Empty;
 import io.grpc.testing.integration.CompressionType;
 import io.grpc.testing.integration.Messages;
 import io.grpc.testing.integration.PayloadType;
@@ -51,10 +52,10 @@ public class GoogleTest {
         // Create gRPC Server
         VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
                 .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
-//                    @Override
-//                    public Single<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
-//                        return Single.error(new RuntimeException("Not yet implemented"));
-//                    }
+                    @Override
+                    public Single<Empty> emptyCall(Empty request) {
+                        return Single.error(new RuntimeException("Not yet implemented"));
+                    }
 
                     // Implement following RPC defined in test.proto:
                     //     rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
@@ -64,10 +65,10 @@ public class GoogleTest {
                                 .setUsername("FooBar"));
                     }
 
-//                    @Override
-//                    public Single<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
-//                        return Single.error(new RuntimeException("Not yet implemented"));
-//                    }
+                    @Override
+                    public Single<Empty> unimplementedCall(Empty request) {
+                        return Single.error(new RuntimeException("Not yet implemented"));
+                    }
 
                     // Implement following RPC defined in test.proto:
                     //     rpc StreamingInputCall(stream StreamingInputCallRequest) returns (StreamingInputCallResponse);

--- a/vertx-grpc-test-rx2/src/test/proto/test.proto
+++ b/vertx-grpc-test-rx2/src/test/proto/test.proto
@@ -42,7 +42,7 @@ option java_package = "io.grpc.testing.integration";
 // performance with various types of payload.
 service TestService {
   // One empty request followed by one empty response.
-  //  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
 
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
@@ -72,18 +72,18 @@ service TestService {
 
 //  // The test server will not implement this method. It will be used
 //  // to test the behavior when clients call unimplemented methods.
-//  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
 }
 
 //// A simple service NOT implemented at servers so clients can test for
 //// that case.
-//service UnimplementedService {
-//  // A call that no server should implement
-//  rpc UnimplementedCall(grpc.testing.Empty) returns(grpc.testing.Empty);
-//}
+service UnimplementedService {
+  // A call that no server should implement
+  rpc UnimplementedCall(grpc.testing.Empty) returns(grpc.testing.Empty);
+}
 //
 //// A service used to control reconnect server.
-//service ReconnectService {
-//  rpc Start(grpc.testing.Empty) returns (grpc.testing.Empty);
-//  rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
-//}
+service ReconnectService {
+  rpc Start(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
+}


### PR DESCRIPTION
The API interface has been updated to use `Single<Empty>` and the `protoFullName` has been changed in the generated POJO class `Empty` to `com.google.protobuf.EmptyProtos.Empty`. Previously, the issue was caused by the generated POJO being identified as `com.google.protobuf.Empty` in both the `toProto` and `fromProto` methods.